### PR TITLE
Add crib block implementation

### DIFF
--- a/src/main/java/com/jeff87654/minecraft/MinecraftMod.java
+++ b/src/main/java/com/jeff87654/minecraft/MinecraftMod.java
@@ -37,12 +37,12 @@ public class MinecraftMod implements ModInitializer {
         // Register the crib block under the mod's namespace.  The identifier
         // consists of the mod ID (minecraftmod) and the path (crib).  This
         // makes the full identifier "minecraftmod:crib".
-        Registry.register(Registries.BLOCK, new Identifier("minecraftmod", "crib"), CRIB);
+        Registry.register(Registries.BLOCK, Identifier.of("minecraftmod", "crib"), CRIB);
 
         // Register the corresponding block item so that players can obtain
         // and place the crib in the world.  Without registering an item the
         // block would exist in the registry but could not be held in an
         // inventory.
-        Registry.register(Registries.ITEM, new Identifier("minecraftmod", "crib"), new BlockItem(CRIB, new Item.Settings()));
+        Registry.register(Registries.ITEM, Identifier.of("minecraftmod", "crib"), new BlockItem(CRIB, new Item.Settings()));
     }
 }

--- a/src/main/java/com/jeff87654/minecraft/block/CribBlock.java
+++ b/src/main/java/com/jeff87654/minecraft/block/CribBlock.java
@@ -1,0 +1,18 @@
+package com.jeff87654.minecraft.block;
+
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.sound.BlockSoundGroup;
+
+/**
+ * Simple block implementation used by the example mod.  Using a dedicated class
+ * avoids class loading failures when Fabric attempts to instantiate the block
+ * referenced from {@link com.jeff87654.minecraft.MinecraftMod}.
+ */
+public class CribBlock extends Block {
+    public CribBlock() {
+        super(AbstractBlock.Settings.create()
+                .strength(2.0f, 3.0f)
+                .sounds(BlockSoundGroup.WOOD));
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple `CribBlock` implementation so the mod's block registration resolves at runtime
- update the block and item registration to use `Identifier.of` compatible with the current Yarn mappings

## Testing
- gradle build *(fails: Gradle could not download required Minecraft native libraries due to HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68ce292acdf08324b27d85537fbc6a9c